### PR TITLE
[FIX] Join Team 삭제 및 문구 개편

### DIFF
--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -36,7 +36,7 @@ export const Navbar = () => {
           <Link href="/" locale={locale}>Home</Link>
           <Link href="/games" locale={locale}>Games</Link>
           <Link href="/events" locale={locale}>Event</Link>
-          <Link href="/programs" locale={locale}>Programs</Link>
+          <Link href="/programs" locale={locale}>Softwares</Link>
           <Link href="/about" locale={locale}>About</Link>
 
           {/* 구분선 */}

--- a/src/app/[locale]/main/page.tsx
+++ b/src/app/[locale]/main/page.tsx
@@ -40,9 +40,9 @@ export default function Home() {
 
         <div className="mt-10 flex flex-wrap gap-4 justify-center">
           <NeonButton label="About Us" href="/about" locale={locale} />
-          <NeonButton label="Projects" href="/games" locale={locale} />
+          <NeonButton label="Games" href="/games" locale={locale} />
+          <NeonButton label="Softwares" href="/programs" locale={locale} />
           <NeonButton label="Events" href="/events" locale={locale} />
-          <NeonButton label="Join Team" href="/team" locale={locale} />
         </div>
       </div>
 

--- a/src/app/[locale]/programs/page.tsx
+++ b/src/app/[locale]/programs/page.tsx
@@ -170,11 +170,6 @@ export default function ProgramsPage() {
                     </svg>
                     {t("download")}
                   </a>
-
-                  {/* Mac & Linux 추가 예정 문구 */}
-                  <p className="text-sm text-neutral-400">
-                    {t("macLinuxComingSoon")}
-                  </p>
                 </div>
 
                 {/* GitHub 링크 버튼 (있는 경우) */}

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -157,7 +157,6 @@
       "version": "Version",
       "platforms": "Platforms",
       "viewOnGitHub": "View on GitHub",
-      "macLinuxComingSoon": "Mac & Linux coming soon",
       "empty": "No programs available at the moment. Check back soon!",
       "comingSoon": {
         "title": "MORE PROGRAMS COMING SOON",

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -130,7 +130,6 @@
       "version": "버전",
       "platforms": "플랫폼",
       "viewOnGitHub": "GitHub에서 보기",
-      "macLinuxComingSoon": "Mac & Linux 추가 예정",
       "empty": "현재 제공되는 프로그램이 없습니다. 곧 업데이트될 예정입니다!",
       "comingSoon": {
         "title": "더 많은 프로그램 개발 예정",


### PR DESCRIPTION
## Join Team 삭제 및 문구 개편
- `Programs` 에서 `Softwares` 로 용어 변경
- 메인메뉴에서 `Join Team` 버튼을 `Softwares` 로 변경 (이젠 팀 모집 섹션으로 이동 불가)
- `Kalivra` 메뉴에 `Mac & Linux 추가 예정` 텍스트 삭제